### PR TITLE
downgrade required twig-bridge version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 	],
 	"require": {
 		"php": ">=5.3.2",
-		"symfony/twig-bundle": "2.1.*"
+		"symfony/twig-bundle": "2.0.*"
 	},
 	"autoload": {
 		"psr-0": {


### PR DESCRIPTION
If symfony 2.1x is not really required. Could you downgrade the composer requirement?
Nice to think about symfony 2.0.X composer users ;)
