### PR TITLE
drop support for passing a `FormView` instance to the `craue_cloneForm` function

### DIFF
--- a/Tests/Twig/Extension/FormExtensionIntegrationTest.php
+++ b/Tests/Twig/Extension/FormExtensionIntegrationTest.php
@@ -46,18 +46,6 @@ class FormExtensionIntegrationTest extends TwigBasedTestCase {
 		$this->assertEquals($form->createView(), $clonedFormView);
 	}
 
-	public function testCloneForm_formView() {
-		$formView = $this->formFactory->createBuilder('form')
-			->add('note', 'text')
-			->getForm()
-			->createView()
-		;
-
-		$clonedFormView = $this->ext->cloneForm($formView);
-
-		$this->assertEquals($formView, $clonedFormView);
-	}
-
 	public function testCloneForm_formType() {
 		if (version_compare(Kernel::VERSION, '2.1.0-DEV', '<')) {
 			$formType = new OldCommentFormType();
@@ -68,6 +56,19 @@ class FormExtensionIntegrationTest extends TwigBasedTestCase {
 		$clonedFormView = $this->ext->cloneForm($formType);
 
 		$this->assertEquals($this->formFactory->create($formType)->createView(), $clonedFormView);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage Expected argument of either type "Symfony\Component\Form\FormTypeInterface" or "Symfony\Component\Form\FormInterface", but "Symfony\Component\Form\FormView" given.
+	 */
+	public function testCloneForm_formView() {
+		$formView = $this->formFactory->createBuilder('form')
+			->getForm()
+			->createView()
+		;
+
+		$this->ext->cloneForm($formView);
 	}
 
 }

--- a/Twig/Extension/FormExtension.php
+++ b/Twig/Extension/FormExtension.php
@@ -5,7 +5,7 @@ namespace Craue\TwigExtensionsBundle\Twig\Extension;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeInterface;
-use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\FormView; // don't use FormViewInterface for Symfony 2.0 compatibility
 
 /**
  * Twig extension for form handling.
@@ -68,11 +68,6 @@ class FormExtension extends \Twig_Extension {
 	 * @throws \InvalidArgumentException
 	 */
 	public function cloneForm($value, array $formOptions = array()) {
-		if ($value instanceof FormView) { // don't use FormViewInterface for Symfony 2.0 compatibility
-			// doesn't work: return clone $value;
-			return unserialize(serialize($value));
-		}
-
 		if ($value instanceof FormInterface) {
 			return $value->createView();
 		}
@@ -84,10 +79,9 @@ class FormExtension extends \Twig_Extension {
 			return $this->formFactory->create($value, null, $formOptions)->createView();
 		}
 
-		throw new \InvalidArgumentException(sprintf('Expected argument of either type "%s", "%s", or "%s", but "%s" given.',
+		throw new \InvalidArgumentException(sprintf('Expected argument of either type "%s" or "%s", but "%s" given.',
 				'Symfony\Component\Form\FormTypeInterface',
 				'Symfony\Component\Form\FormInterface',
-				'Symfony\Component\Form\FormView',
 				is_object($value) ? get_class($value) : gettype($value)
 		));
 	}

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,0 +1,27 @@
+# Upgrade from 1.0.x to 2.0
+
+## Function `craue_cloneForm`
+
+- Passing a `FormView` instance is no longer supported. You'll have to pass its underlying `Form` instance instead, i.e. remove the `createView` call in your action.
+
+	before:
+	```php
+	// in your action
+	return $this->render('MyCompanyMyBundle:MyStuff:myTemplate.html.twig', array(
+		'form' => $form->createView(),
+	));
+
+	// in your template
+	{{ form_widget(cloneForm(form)) }}
+	```
+
+	after:
+	```php
+	// in your action
+	return $this->render('MyCompanyMyBundle:MyStuff:myTemplate.html.twig', array(
+		'form' => $form,
+	));
+
+	// in your template
+	{{ form_widget(cloneForm(form)) }}
+	```


### PR DESCRIPTION
A code change in Symfony 2.5 prevents serializing `FormView`s, see symfony/symfony#10839. As a consequence, support for passing a `FormView` instance to the `craue_cloneForm` function will be dropped.
